### PR TITLE
add support for passing in cargo features

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,28 @@ You can also configure these versions like so:
 steps:
   - uses: actions/checkout@v3
   - uses: metadaoproject/anchor-test@v1.2
-    with: 
-      anchor-version: '0.24.2' 
+    with:
+      anchor-version: '0.24.2'
       solana-cli-version: '1.10.32'
       node-version: '16.15.1'
 ```
+
+### Cargo Features
+
+You can pass in features to cargo via `anchor test` by using the `features` input:
+
+```yaml
+steps:
+  - uses: actions/checkout@v3
+  - uses: metadaoproject/anchor-test@v1.2
+    with: 
+      anchor-version: '0.24.2'
+      solana-cli-version: '1.10.32'
+      node-version: '16.15.1'
+      features: 'my-feature'
+```
+
+This defaults to 'default'.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Version of Anchor to use'
     required: false
     default: '0.27.0' # latest
+  features:
+    description: 'Features to pass to cargo'
+    required: false
+    default: 'default'
 runs:
   using: 'composite'
   steps:
@@ -47,6 +51,6 @@ runs:
     - name: Cache Cargo dependencies
       uses: Swatinem/rust-cache@v2
     - name: Run tests
-      run: anchor test
+      run: anchor test -- --features {{ inputs.features }}
       shell: bash
 


### PR DESCRIPTION
This PR adds support for passing in features to `cargo` via the `anchor test` command. If you don't think it's generally useful enough, feel free to close the PR. I forked this action and added this feature for a project, so figured it was worth contributing back in case you want to merge it.